### PR TITLE
Configurable logger levels

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -9,8 +9,7 @@ var Promise = require('bluebird');
 var bodyParser = require('body-parser');
 
 var Application = module.exports = function (name, path, gryd, global) {
-    var level = (/dev|local/i.test(gryd.env)) ? 'debug' : 'info';
-    this.log = Bunyan.createLogger({name: `${name}.${gryd.env}.${gryd.forkNum}`, stream: formatOut, level: level});
+    this.log = Bunyan.createLogger({name: `${name}.${gryd.env}.${gryd.forkNum}`, stream: formatOut, level: 'info'});
     this.name = name;
     this.path = path;
     this.gryd = gryd;
@@ -18,8 +17,6 @@ var Application = module.exports = function (name, path, gryd, global) {
     this.app = null;
     this.db = null;
     this.config = null;
-    this.log.debug('Bunyan logger set at level: ' + level);
-    this.log.debug('Running GRYD DEV');
 
 };
 
@@ -67,6 +64,14 @@ Application.prototype.loadConfig = function (callback) {
             if (self.config.requestLog) {
                 self.app.use(self.logRequest.bind(self));
             }
+
+            // Sets the logger level depending on environment configs
+            let level = self.config.loggerLevel || 'info';
+            self.log.level(level);
+            self.log.debug('Bunyan logger set at level: ' + level);
+
+            self.log.debug('Running GRYD DEV');
+
             callback();
         } else {
             callback("Configuration for environment " + env + " does not exist");


### PR DESCRIPTION
Uses `loggerLevel` config property to set the logger's level, rather than just checking if it is "dev" or "local".