### PR TITLE
Socket.io support

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -90,7 +90,7 @@ Application.prototype.connectDatabase = function (callback) {
             connectTimeoutMS: 30000,
             connectWithNoPrimary: true,
             poolSize: 2,
-            useNewUrlParser: true
+            // useNewUrlParser: true
         };
 
         self.log.debug('DB: ' + self.config.db);

--- a/lib/application.js
+++ b/lib/application.js
@@ -8,12 +8,12 @@ var async = require('async');
 var Promise = require('bluebird');
 var bodyParser = require('body-parser');
 
-var Application = module.exports = function (name, path, gryd, global) {
+var Application = module.exports = function (name, path, gryd, httpServer) {
     this.log = Bunyan.createLogger({name: `${name}.${gryd.env}.${gryd.forkNum}`, stream: formatOut, level: 'info'});
     this.name = name;
     this.path = path;
     this.gryd = gryd;
-    this.global = global;
+    this.httpServer = httpServer;
     this.app = null;
     this.db = null;
     this.config = null;

--- a/lib/application.js
+++ b/lib/application.js
@@ -86,13 +86,11 @@ Application.prototype.connectDatabase = function (callback) {
         mongoose.Promise = Promise;
         //mongoose.connect(self.config.db);
         var opts = {
-            replset: {
-                socketOptions: {
-                    keepAlive: 1, connectTimeoutMS: 30000
-                },
-                poolSize: 2,
-                connectWithNoPrimary: true
-            }
+            keepAlive: 1,
+            connectTimeoutMS: 30000,
+            connectWithNoPrimary: true,
+            poolSize: 2,
+            useNewUrlParser: true
         };
 
         self.log.debug('DB: ' + self.config.db);

--- a/lib/gryd.js
+++ b/lib/gryd.js
@@ -24,6 +24,7 @@ var formatOut = bformat({outputMode: 'short'});
 var Express = require('./express');
 var Application = require('./application');
 var _ = require('lodash');
+var http = require('http');
 
 var grydconfig = {
     port: process.env.gryd_port || 8000,
@@ -77,6 +78,7 @@ module.exports = function (app_path, gryd_opts) {
             } else {
                 Logger.info(`Starting fork ${grydconfig.forkNum}...`);
                 var GlobalApp = Express();
+                var server = http.Server(GlobalApp);
 
                 GlobalApp.disable('x-powered-by');
                 initialize(app_path, files, function (Apps) {
@@ -84,14 +86,14 @@ module.exports = function (app_path, gryd_opts) {
                         var App = Apps[i];
                         GlobalApp.use("/" + App.name, App.app);
                     }
-                    GlobalApp.listen(grydconfig.port);
-                }, GlobalApp);
+                    server.listen(grydconfig.port);
+                }, server);
             }
         }
     });
 };
 
-function initialize(app_path, files, callback, GlobalApp) {
+function initialize(app_path, files, callback, httpServer) {
     var Apps = [];
     var finished = _.after(files.length, function () {
         callback(Apps);
@@ -99,7 +101,7 @@ function initialize(app_path, files, callback, GlobalApp) {
     for (var i in files) {
         var app_name = files[i];
         var path = app_path + "/" + app_name;
-        var app = new Application(app_name, path, grydconfig, GlobalApp);
+        var app = new Application(app_name, path, grydconfig, httpServer);
         if (cluster.isMaster) {
             app.initMaster(function (err, self) {
                 if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,14 +55,9 @@
       }
     },
     "bson": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
-      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
     },
     "bunyan": {
       "version": "1.8.10",
@@ -111,11 +106,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "debug": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
@@ -152,11 +142,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
-    },
-    "es6-promise": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -250,11 +235,6 @@
       "resolved": "https://registry.npmjs.org/gryd-validator/-/gryd-validator-0.1.3.tgz",
       "integrity": "sha1-sYol7kANbA5WsvIWzNA7VvDwjpU="
     },
-    "hooks-fixed": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz",
-      "integrity": "sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ=="
-    },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
@@ -286,15 +266,10 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
       "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew="
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
     "kareem": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
-      "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.2.1.tgz",
+      "integrity": "sha512-xpDFy8OxkFM+vK6pXy6JmH92ibeEFUuDWzas5M9L7MzVmHW3jzwAHxodCPV/BYkf4A31bVDLyonrMfp9RXb/oA=="
     },
     "lodash": {
       "version": "2.4.2",
@@ -370,48 +345,46 @@
       "optional": true
     },
     "mongodb": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.34.tgz",
-      "integrity": "sha1-o09Zu+thdUrsQy3nLD/iFSakTBo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.1.tgz",
+      "integrity": "sha512-GU9oWK4pi8PC7NyGiwjFMwZyMqwGWoMEMvM0LZh7UKW/FFAqgmZKjjriD+5MEOCDUJE2dtHX93/K5UtDxO0otg==",
       "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.18",
-        "readable-stream": "2.2.7"
+        "mongodb-core": "3.1.0"
       }
     },
     "mongodb-core": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.18.tgz",
-      "integrity": "sha1-TEYTm986HwMt7ZHbSfOO7AFlkFA=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.0.tgz",
+      "integrity": "sha512-qRjG62Fu//CZhkgn0jA/k8jh5MhACIq8cOJUryH6sck87pgt+C222MSD02tsCq5zNo/B6ZFHtNodZ2qpf8E86g==",
       "requires": {
-        "bson": "1.0.6",
-        "require_optional": "1.0.1"
+        "bson": "1.0.9",
+        "require_optional": "1.0.1",
+        "saslprep": "1.0.1"
       }
     },
     "mongoose": {
-      "version": "4.13.14",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.14.tgz",
-      "integrity": "sha512-20zynb1fvCO37AP+0iTPGDbt4dJJkzM9fNK5BwKf5n+gFU5YYdXpnhxs9Kf8C+Fe0xY8vpUKV8wA7VGWcmDaFw==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.2.7.tgz",
+      "integrity": "sha512-LI3V/mYj3SHy29dUQvbmS8tKeDS5Ljm1LIfiyCIPNX10KxzDfMQYgh92Umzb6lV6Z/MayKy2HtpNTYHzDU+6xw==",
       "requires": {
-        "async": "2.6.0",
-        "bson": "1.0.6",
-        "hooks-fixed": "2.0.2",
-        "kareem": "1.5.0",
+        "async": "2.6.1",
+        "bson": "1.0.9",
+        "kareem": "2.2.1",
         "lodash.get": "4.4.2",
-        "mongodb": "2.2.34",
-        "mpath": "0.3.0",
-        "mpromise": "0.5.5",
-        "mquery": "2.3.3",
+        "mongodb": "3.1.1",
+        "mongodb-core": "3.1.0",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.4.1",
+        "mquery": "3.1.2",
         "ms": "2.0.0",
-        "muri": "1.3.0",
         "regexp-clone": "0.0.1",
         "sliced": "1.0.1"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
             "lodash": "4.17.10"
           }
@@ -423,39 +396,39 @@
         }
       }
     },
-    "mpath": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
-      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
-    "mpromise": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
-      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
+    "mpath": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.4.1.tgz",
+      "integrity": "sha512-NNY/MpBkALb9jJmjpBlIi6GRoLveLUM0pJzgbp9vY9F7IQEb/HREC/nxrixechcQwd1NevOhJnWWV8QQQRE+OA=="
     },
     "mquery": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
-      "integrity": "sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.1.2.tgz",
+      "integrity": "sha512-rBo2+eShI/Ko/GFzXMvJvYjzeLRW3P7E4NllAGRyNO90Xw5awo5RI3zCqzuJWe1NSvdL7cGu3RPLuGjZ1TmnmA==",
       "requires": {
-        "bluebird": "3.5.0",
-        "debug": "2.6.9",
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
         "regexp-clone": "0.0.1",
-        "sliced": "0.0.5"
+        "sliced": "1.0.1"
       },
       "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "sliced": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
         }
       }
     },
@@ -463,11 +436,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "muri": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz",
-      "integrity": "sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg=="
     },
     "mv": {
       "version": "2.1.1",
@@ -534,11 +502,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
@@ -557,20 +520,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "readable-stream": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-      "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
     },
     "regexp-clone": {
       "version": "0.0.1",
@@ -600,15 +549,16 @@
         "glob": "6.0.4"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "safe-json-stringify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
       "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
+      "optional": true
+    },
+    "saslprep": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.1.tgz",
+      "integrity": "sha512-ntN6SbE3hRqd45PKKadRPgA+xHPWg5lPSj2JWJdJvjTwXDDfkPVtXWvP8jJojvnm+rAsZ2b299C5NwZqq818EA==",
       "optional": true
     },
     "semver": {
@@ -662,14 +612,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -683,11 +625,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "gryd-docs": "^0.1.2",
     "gryd-validator": "^0.1.3",
     "lodash": "^2.4.1",
-    "mongoose": "^4.13.14"
+    "mongoose": "^5.2.7"
   }
 }


### PR DESCRIPTION
- Updates Mongoose to 5.2.7
  - Flatten mongoose server config object as needed by new specifications
- Exposes global http server so Socket.io can hook into it


Needed for: https://jira.bullhorn.com/browse/FYRE-1309