### PR TITLE
Configurable Mongoose PoolSize

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -90,7 +90,7 @@ Application.prototype.connectDatabase = function (callback) {
             keepAlive: 1,
             connectTimeoutMS: 30000,
             connectWithNoPrimary: true,
-            poolSize: (self.gryd && self.gryd.mongoosePoolSize) || 5,
+            poolSize: (self.gryd && parseInt(self.gryd.mongoosePoolSize)) || 5,
             // useNewUrlParser: true
         };
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -90,7 +90,7 @@ Application.prototype.connectDatabase = function (callback) {
             keepAlive: 1,
             connectTimeoutMS: 30000,
             connectWithNoPrimary: true,
-            poolSize: 2,
+            poolSize: 5,
             // useNewUrlParser: true
         };
 

--- a/lib/application.js
+++ b/lib/application.js
@@ -90,7 +90,7 @@ Application.prototype.connectDatabase = function (callback) {
             keepAlive: 1,
             connectTimeoutMS: 30000,
             connectWithNoPrimary: true,
-            poolSize: 5,
+            poolSize: (self.gryd && self.gryd.mongoosePoolSize) || 5,
             // useNewUrlParser: true
         };
 

--- a/lib/gryd.js
+++ b/lib/gryd.js
@@ -29,6 +29,7 @@ var http = require('http');
 var grydconfig = {
     port: process.env.gryd_port || 8000,
     env: process.env.gryd_environment || "dev",
+    mongoosePoolSize: process.env.mongoose_pool_size || 5,
     forkNum: process.env.gryd_fork_num || 0
 };
 var level = (/dev|local/i.test(grydconfig.env)) ? 'debug' : 'info';


### PR DESCRIPTION
Configured via `process.env.mongoose_pool_size`, defaults to 5